### PR TITLE
WIP: Cleanup dashboard plugin add small optimization on recursive calls

### DIFF
--- a/.changeset/popular-bananas-wash.md
+++ b/.changeset/popular-bananas-wash.md
@@ -1,0 +1,5 @@
+---
+"@module-federation/dashboard-plugin": patch
+---
+
+Cleanup dashboard plugin add small optimization on recursive calls


### PR DESCRIPTION
Needs review. Moved lots of code around no real functionality changes here. In `buildVedorFederationMap` these lines are commented out  `// subPackages: this.directReasons(modules)` as that is not an option on `AutomaticVendorFederation`. Left comments in case they need to be put back in. Only other change here is in `mapToObjectRec` added a check for the map || sets size to be > 0. We were making recursive calls with empty sets && maps.