### PR TITLE
Add default publishVersion for the remotes to work without param provided by Plugin config

### DIFF
--- a/dashboard-plugin/FederationDashboardPlugin.js
+++ b/dashboard-plugin/FederationDashboardPlugin.js
@@ -95,7 +95,7 @@ class FederationDashboardPlugin {
       federationRemoteEntry: RemoteEntryChunk,
       buildHash: stats.hash,
       environment: this._options.environment, // 'development' if not specified
-      version: this._options.publishVersion, // '1.0.0' if not specified
+      version: this._options.publishVersion || "1.0.0", // '1.0.0' if not specified
       posted: this._options.posted, // Date.now() if not specified
       group: this._options.group, // 'default' if not specified
       modules,

--- a/dashboard-plugin/README.md
+++ b/dashboard-plugin/README.md
@@ -26,12 +26,13 @@ This will post the `ModuleFederationPlugin` metrics to the update endpoint at `h
 
 There are also other options:
 
-| Key          | Description                                                                             |
-| ------------ | --------------------------------------------------------------------------------------- |
-| dashboardURL | The URL of the dashboard endpoint.                                                      |
-| metadata     | Any additional metadata you want to apply to this application for use in the dashboard. |
-| filename     | The file path where the dashboard data.                                                 |
-| standalone   | For use without ModuleFederationPlugin                                                  |
+| Key            | Description                                                                             |
+| -------------- | --------------------------------------------------------------------------------------- |
+| dashboardURL   | The URL of the dashboard endpoint.                                                      |
+| metadata       | Any additional metadata you want to apply to this application for use in the dashboard. |
+| filename       | The file path where the dashboard data.                                                 |
+| standalone     | For use without ModuleFederationPlugin                                                  |
+| publishVersion | Used for versioned remotes. '1.0.0' will be used for each remote if not passed          |
 
 ## Metadata
 


### PR DESCRIPTION
# RATIONALE
When using DashboardPlugin on any of the remotes without specifying `publishVersion` explicitly next error was showing up in the console:

![image](https://user-images.githubusercontent.com/6311961/115538213-52a7d880-a2a4-11eb-9fb7-7835f603ee3f.png)


## CHNAGES
- added default value for the piblishVersion in passed options
- added respective changes to README.md