### PR TITLE
Fix repo Url

### DIFF
--- a/dashboard-plugin/package.json
+++ b/dashboard-plugin/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/module-federation/medusa.git"
+    "url": "https://github.com/module-federation/federation-dashboard.git"
   },
   "files": [
     "bin",


### PR DESCRIPTION
Current Git URL returns 404.
Changed it with https://github.com/module-federation/federation-dashboard.git