### PR TITLE
Reset changeset files to fix broken actions

### DIFF
--- a/.changeset/beige-wasps-greet.md
+++ b/.changeset/beige-wasps-greet.md
@@ -1,6 +1,0 @@
----
-"@module-federation/dashboard-plugin": minor
-"@module-federation/dashboard-plugin": minor
----
-
-Write mode and Active module management

--- a/.changeset/beige-wasps-greet.md
+++ b/.changeset/beige-wasps-greet.md
@@ -1,5 +1,5 @@
 ---
-"@module-federation/dashboard": minor
+"@module-federation/dashboard-plugin": minor
 "@module-federation/dashboard-plugin": minor
 ---
 

--- a/.changeset/nice-olives-switch.md
+++ b/.changeset/nice-olives-switch.md
@@ -1,5 +1,0 @@
----
-"@module-federation/dashboard-plugin": minor
----
-
-Enable Standalone mode

--- a/.changeset/nice-olives-switch.md
+++ b/.changeset/nice-olives-switch.md
@@ -1,5 +1,5 @@
 ---
-"@module-federation/dashboard": minor
+"@module-federation/dashboard-plugin": minor
 ---
 
 Enable Standalone mode

--- a/.changeset/seven-cougars-drop.md
+++ b/.changeset/seven-cougars-drop.md
@@ -1,5 +1,5 @@
 ---
-"@module-federation/dashboard": minor
+"@module-federation/dashboard-plugin": minor
 ---
 
 Adding Mongo Driver, Improving auth and SSO, fix cors and auth api endpoints

--- a/.changeset/seven-cougars-drop.md
+++ b/.changeset/seven-cougars-drop.md
@@ -1,5 +1,0 @@
----
-"@module-federation/dashboard-plugin": minor
----
-
-Adding Mongo Driver, Improving auth and SSO, fix cors and auth api endpoints

--- a/.changeset/twenty-monkeys-drum.md
+++ b/.changeset/twenty-monkeys-drum.md
@@ -1,6 +1,0 @@
----
-"@module-federation/dashboard-plugin": minor
-"@module-federation/dashboard-plugin": minor
----
-
-Plugin writes versioned remotes on its own. Fixed dashboard db delays on versioned modules reflecting in BE

--- a/.changeset/twenty-monkeys-drum.md
+++ b/.changeset/twenty-monkeys-drum.md
@@ -1,5 +1,5 @@
 ---
-"@module-federation/dashboard": minor
+"@module-federation/dashboard-plugin": minor
 "@module-federation/dashboard-plugin": minor
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Step 3:
 Globally install and launch the dashboard:
 
 ```shell script
-> npm install -g @module-federation/dashboard
+> npm install -g @module-federation/dashboard-plugin
 > mfdash
 ```
 


### PR DESCRIPTION
This PR fixes the broken pipeline by removing old changeset files with the old package names.
Before merging it, ensure that the [default permissions for GITHUB_TOKEN](https://github.com/brunos3d/federation-dashboard/settings/actions#:~:text=Workflow%20permissions) are like the image below.

![image](https://github.com/module-federation/federation-dashboard/assets/21183964/4e3923b9-b5c3-4932-b5d1-b7a78a075366)
