### PR TITLE
docs: contribution guide and summarizes the latest changes

### DIFF
--- a/.changeset/neat-feet-allow.md
+++ b/.changeset/neat-feet-allow.md
@@ -1,0 +1,119 @@
+---
+"@module-federation/dashboard-plugin": patch
+---
+
+Huge overview of latest changes, this change also introduces a contribution guide to help contributors understand the process of creating new changesets and PRs.
+
+### Commits on Sep 13, 2023:
+
+Added a new feature to enable cache buster.
+Updated a client version file.
+Made some code style fixes and removed comments.
+
+### Commits on Sep 6, 2023:
+
+Fixed changeset.
+Merged changes from the remote master branch.
+
+### Commits on Sep 1, 2023:
+
+Added a feature related to timeout and fallback for the client version.
+
+### Commits on Jun 29, 2023:
+
+Made a version update.
+Made changes related to Medusa delegate.
+
+### Commits on Jan 18, 2023:
+
+Added Medusa delegate modules.
+
+### Commits on Nov 2, 2022:
+
+Made various fixes and updates.
+Fixed issues related to CI and webpack.
+Removed old package names and changeset files.
+
+### Commits on Sep 22, 2022:
+
+Created new apps and plugins for testing.
+
+### Commits on Aug 10, 2022:
+
+Made version updates and fixed webpack errors.
+
+### Commits on Aug 9, 2022:
+
+Made various updates and fixes.
+Updated Node.js and dependencies.
+
+### Commits on Jul 13, 2022:
+
+Made changes related to version strategy.
+
+### Commits on Jul 11, 2022:
+
+Added support for Next.js.
+Updated dependencies like serve and node-fetch.
+Fixed temporary issues.
+
+### Commits on Jul 8, 2022:
+
+Updated injector to load the remote in a simpler format.
+Removed GraphQL from an API endpoint.
+Fixed token issues.
+
+### Commits on Jul 6, 2022:
+
+Added Git SHA to objects.
+Enabled stats file output.
+Made various updates and fixes.
+
+### Commits on Jul 1, 2022:
+
+Updated endpoints.
+
+### Commits on Jun 27, 2022:
+
+Made version updates.
+Updated injector and API to serve a simpler format for loading the remote.
+
+### Commits on May 6, 2022:
+
+Fixed configurations to help setup work.
+
+### Commits on Apr 22, 2022:
+
+Fixed database store.
+
+### Commits on Mar 17, 2022:
+
+Updated dependencies and fixed build issues.
+Added timers for debugging.
+
+### Commits on Jan 11, 2022:
+
+Updated less dependency.
+
+### Commits on Oct 29, 2021:
+
+Updated Yarn and webpack dependencies.
+
+### Commits on Sep 24, 2021:
+
+Fixed issues related to plugin tokens.
+
+### Commits on Sep 21, 2021:
+
+Added more timers for debugging.
+Made changes to cache settings.
+
+### Commits on Sep 20, 2021:
+
+Made various changes to cache settings, prefetch, and public cache.
+
+### Commits on Sep 19, 2021:
+
+Made changes to buttons, cache headers, and JSON bindings.
+Added new remote versions and endpoints.
+This summary provides an overview of the changes made in the repository, including new features, bug fixes, dependency updates, and other improvements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Thanks you for your contribution!
+
+## commits
+
+- must be followed by conventional commits
+
+## version release
+
+The project is using changesets to manage the versioning, so you need to create a changeset file before creating a PR, you can do that by running the following command:
+
+```bash
+yarn changeset
+```
+
+After providing the necessary information, a changeset file will be created in the `.changeset` folder, you need to commit this file with your changes.
+
+## PR
+
+After creating a PR, the CI will run the tests and linting, if everything is ok, the PR will be merged to the `main` branch.
+
+## release
+
+After merging the PR to the `main` branch, the CI will run the tests and linting, if everything is ok, the CI will create a new release and publish it to the npm registry.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ The project is using changesets to manage the versioning, so you need to create 
 
 ```bash
 yarn changeset
+yarn changeset version
 ```
 
 After providing the necessary information, a changeset file will be created in the `.changeset` folder, you need to commit this file with your changes.


### PR DESCRIPTION
Huge overview of the latest changes. These changes also introduce a contribution guide to help contributors understand the process of creating new changesets and PRs.

It's important to note the involved developers on the project use `yarn changeset` before creating pushing/merging new releases.